### PR TITLE
Test creating PR from command line with hub

### DIFF
--- a/Day-2.md
+++ b/Day-2.md
@@ -2,6 +2,7 @@
 
 I'm going to continue to learn the hub CLI and try creating a PR for each day of code log entry. 
 
+I misunderstood the boilerplate instructions for creating a PR from hub. I am making a test branch to try again.
 
 ****
 <p align="center"> <a href="https://www.buymeacoffee.com/nikema" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" width="150px"></a></center></p>


### PR DESCRIPTION
This should show up in the PR description. I realized that when I use the message (-m) option, I don't get this text editor to write the description and the PR is automatically created.